### PR TITLE
[Ready] Junit XML Report Generation for Notebooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ pip-run: &pip-install
     python3 -m venv venv
     . venv/bin/activate
     pip install -r pip-requirements.txt
-    pip install astropy_helpers sphinx pytest
+    pip install astropy_helpers sphinx pytest junit_xml
     pip install git+https://github.com/jupyter/nbconvert
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 
         # We need to install the master/latest version of nbconvert because it has support for
         # allowing exceptions in individual cells:
-        - PIP_DEPENDENCIES='git+https://github.com/jupyter/nbconvert'
+        - PIP_DEPENDENCIES='git+https://github.com/jupyter/nbconvert junit_xml'
 
 # matrix:
 

--- a/nbpages/reporter.py
+++ b/nbpages/reporter.py
@@ -3,6 +3,8 @@ import re
 import html
 import traceback
 
+from warnings import warn
+
 class Reporter(object):
     def __init__(self):
         self.test_cases = []
@@ -26,7 +28,7 @@ class Reporter(object):
             global TestSuite, TestCase
             from junit_xml import TestSuite, TestCase
         except ImportError:
-            print('Failed to Import junit_xml, required to create report.')
+            warn('Failed to import junit_xml, required to create report.')
 
 
     @staticmethod

--- a/nbpages/reporter.py
+++ b/nbpages/reporter.py
@@ -16,20 +16,22 @@ class Reporter(object):
         Imports junit_xml and activates the reporter.
         This allows all functions with imports to execute.
         """
-        self.junit_xml_import()
-        self.activated = True
+        self.activated = self._junit_xml_import()
 
 
-    def junit_xml_import(self):
+    def _junit_xml_import(self):
         """
         Imports junit_xml which is required to format reports for use in CI.
+
+        Returns True if import succeeded, False otherwise
         """
         try:
             global TestSuite, TestCase
             from junit_xml import TestSuite, TestCase
+            return True
         except ImportError:
             warn('Failed to import junit_xml, required to create junit-style report.')
-
+            return False
 
     @staticmethod
     def format_error(e):

--- a/nbpages/reporter.py
+++ b/nbpages/reporter.py
@@ -1,0 +1,103 @@
+import os
+import re
+import html
+import traceback
+
+class Reporter(object):
+    def __init__(self):
+        self.test_cases = []
+        self.activated = False
+
+
+    def activate(self):
+        """
+        Imports junit_xml and activates the reporter.
+        This allows all functions with imports to execute.
+        """
+        self.junit_xml_import()
+        self.activated = True
+
+
+    def junit_xml_import(self):
+        """
+        Imports junit_xml which is required to format reports for use in CI.
+        """
+        try:
+            global TestSuite, TestCase
+            from junit_xml import TestSuite, TestCase
+        except ImportError:
+            print('Failed to Import junit_xml, required to create report.')
+
+
+    @staticmethod
+    def format_error(e):
+        """
+        Exceptions from nbconvert use ansii color escape sequences
+        which are not pretty in console outputs that dont support this (jenkins).
+        This function cleans up the exception message.
+        """
+        if isinstance(e, Exception):
+            # error is an exception, format accordingly
+            ansi_escape = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]')
+            return html.unescape(ansi_escape.sub('',
+                                ''.join(traceback.format_exception(etype=type(e),
+                                value=e, tb=e.__traceback__))))
+        elif isinstance(e, str):
+            # error is a string
+            return html.unescape(e)
+        else:
+            return ''
+
+
+    def add_test_case(self, test_name=None, nb_name=None, nb_file=None):
+        """
+        Creates a new test case and adds it to list of test cases.
+        """
+        if self.activated:
+            tc = TestCase(test_name, nb_name.replace("_", " "),
+                            0, '', '', file=nb_file)
+            self.test_cases.append(tc)
+
+
+    def add_execution_time(self, seconds=0):
+        """
+        Add execution time in seconds to last test case.
+        """
+        if self.activated:
+            self.test_cases[-1].elapsed_sec = seconds
+
+
+    def add_error(self, message=None, error_type=None):
+        """
+        Add an error to last test case.
+        """
+        if self.activated:
+            self.test_cases[-1].add_error_info(
+                                message=self.format_error(message),
+                                error_type=error_type)
+
+
+    def add_std_out(self, message=None):
+        """
+        Add std out message to last test case.
+        """
+        if self.activated:
+            self.test_cases[-1].stdout = self.format_error(message)
+
+
+    def create_report(self, report_file=None, suite_name='Test Suite', suite_package='root'):
+        """
+        Create a test suite and write report to file specified
+        in report_file.
+
+        Note: depending on system, mode may need to be set to wb
+        """
+        if self.activated and report_file:
+            if '.xml'.casefold() not in report_file.casefold():
+                report_file = report_file.split('.')[0] + '.xml'
+
+            ts = [TestSuite(suite_name, self.test_cases, package=suite_package)]
+            with open(report_file, mode='w') as f:
+                TestSuite.to_file(f, ts, prettyprint=True)
+                print('Test report written to {}'.format(os.path.abspath(f.name)))
+                f.close()

--- a/nbpages/reporter.py
+++ b/nbpages/reporter.py
@@ -88,16 +88,25 @@ class Reporter(object):
     def create_report(self, report_file=None, suite_name='Test Suite', suite_package='root'):
         """
         Create a test suite and write report to file specified
-        in report_file.
+        in report_file.  Returns the resulting report string (or None if not
+        activated.)
 
-        Note: depending on system, mode may need to be set to wb
+
         """
-        if self.activated and report_file:
+        if self.activated:
             if '.xml'.casefold() not in report_file.casefold():
                 report_file = report_file.split('.')[0] + '.xml'
 
             ts = [TestSuite(suite_name, self.test_cases, package=suite_package)]
-            with open(report_file, mode='w') as f:
-                TestSuite.to_file(f, ts, prettyprint=True)
-                print('Test report written to {}'.format(os.path.abspath(f.name)))
-                f.close()
+
+            xmls = TestSuite.to_xml_string(ts, prettyprint=True)
+            if report_file:
+                if hasattr(report_file, 'write'):
+                    # assume file-like
+                    report_file.write(xmls)
+                else:
+                    # Note: depending on system, mode may need to be set to wb
+                    with open(report_file, mode='w') as f:
+                        f.write(xmls)
+                    print('Test report written to {}'.format(os.path.abspath(f.name)))
+            return xmls

--- a/nbpages/reporter.py
+++ b/nbpages/reporter.py
@@ -28,7 +28,7 @@ class Reporter(object):
             global TestSuite, TestCase
             from junit_xml import TestSuite, TestCase
         except ImportError:
-            warn('Failed to import junit_xml, required to create report.')
+            warn('Failed to import junit_xml, required to create junit-style report.')
 
 
     @staticmethod
@@ -92,8 +92,6 @@ class Reporter(object):
         Create a test suite and write report to file specified
         in report_file.  Returns the resulting report string (or None if not
         activated.)
-
-
         """
         if self.activated:
             if '.xml'.casefold() not in report_file.casefold():


### PR DESCRIPTION
Added generation of junit xml format test reports (readable by CI) for execution and checking of notebooks.

CellExecutionErrors no longer raise error, instead they log the error and add an error for that notebook to the test report. This allows converting of notebooks if one fails (as we have commonly seen with failed db queries)

Generates xml reports using (example as used in notebooks repo)

```
python convert.py --report filename.xml
```

will then generate a filename.xml file with Junit formatted xml for use in CI.

<img width="1134" alt="screen shot 2019-03-05 at 2 01 43 pm" src="https://user-images.githubusercontent.com/20295433/53830071-a1247c80-3f4f-11e9-910b-5accca254c27.png">
