### PR TITLE
Add option for only checking changed notebooks

### DIFF
--- a/nbpages/converter.py
+++ b/nbpages/converter.py
@@ -333,7 +333,7 @@ def get_changed():
                     'nb_html.tpl', 'pages.css', 'gh_pages_deploy.sh']
 
     # This command will list all changed files on current commit from master.
-    list_changed_files_cmd = "git show --pretty=format: --name-only -r master"
+    list_changed_files_cmd = "git show --pretty=format: --name-only -r {}".format(base_branch)
 
     # Get list of changed files using git
     # git must be installed and accessible from the calling shell
@@ -457,6 +457,8 @@ def run_parsed(nbfile_or_path, output_type, args, **kwargs):
                       .format(template_file))
 
     if args.changed:
+        if args.include is not None:
+            raise ValueError("cannot give an explicit include list and ask for only changed notebooks at the same time")
         args.include = get_changed()
         if args.include is None:
             args.exclude = '.*'

--- a/nbpages/converter.py
+++ b/nbpages/converter.py
@@ -342,6 +342,12 @@ def get_changed(base_branch):
     changed_files = subprocess.check_output(list_changed_files_cmd,
                                     shell=True).decode().strip().split('\n')
 
+
+
+    non_global = ('.ipynb', '.md', '.rst')
+
+    global_changed_files = [f for f in file_names if not  os.path.basename(f).endswith(non_global)]
+
     # Determine if global file was changed
     global_change = any(f in [path.basename(x) for x in changed_files]
             for f in global_files) or '.circleci' in [path.dirname(x)

--- a/nbpages/converter.py
+++ b/nbpages/converter.py
@@ -321,12 +321,14 @@ def clean_keyword(kw):
     return kw.strip().title().replace('.', '').replace('/', '').replace(' ', '')
 
 
-def get_changed():
+def get_changed(base_branch):
     '''
     Returns the names of new/changed notebooks on current commit.
     Returns .* if any global or .circleci/*  files were changed.
     Returns None if no files were changed on current commit.
     '''
+    if not base_branch:
+        base_branch = 'master'
 
     # List of any files that when changed should convert all notebooks
     global_files = ['convert.py', 'environment.yml', 'index.tpl',
@@ -418,9 +420,10 @@ def make_parser(parser=None):
                              'include. Cannot be given at the same time as '
                              'exclude.')
 
-    parser.add_argument('--changed', default=None, action="store_true", dest='changed',
-                        help='Signals a check/conversion for only changed files.'
-                             'Only converts changed notebook files.')
+    parser.add_argument('--changed', default=None, dest='changed',
+                        help='Signals a check for changed files'
+                             ' on current commit from the specified branch.'
+                             'Only converts impacted notebooks.')
 
     parser.add_argument('--report', default=None, dest='report_file',
                         help='The path and file name to write a Junit XML '
@@ -459,7 +462,7 @@ def run_parsed(nbfile_or_path, output_type, args, **kwargs):
     if args.changed:
         if args.include is not None:
             raise ValueError("cannot give an explicit include list and ask for only changed notebooks at the same time")
-        args.include = get_changed()
+        args.include = get_changed(args.changed)
         if args.include is None:
             args.exclude = '.*'
         else:

--- a/nbpages/reporter.py
+++ b/nbpages/reporter.py
@@ -96,13 +96,13 @@ class Reporter(object):
         activated.)
         """
         if self.activated:
-            if '.xml'.casefold() not in report_file.casefold():
-                report_file = report_file.split('.')[0] + '.xml'
-
             ts = [TestSuite(suite_name, self.test_cases, package=suite_package)]
 
             xmls = TestSuite.to_xml_string(ts, prettyprint=True)
             if report_file:
+                if '.xml'.casefold() not in report_file.casefold():
+                    report_file = report_file.split('.')[0] + '.xml'
+
                 if hasattr(report_file, 'write'):
                     # assume file-like
                     report_file.write(xmls)


### PR DESCRIPTION
Added arg option for only checking notebooks that were changed. This is useful in PRs as it can skip all unchanged notebooks. Implementation is then used in convert.py script (in notebooks repo).

This addition allows the convert script to only execute/convert notebooks that were changed/added in the current commit. Calling the convert script with `python convert.py --changed`signals the script to only check/execute notebooks that were changed on the current git commit from the master branch.

If a global file was changed in the root or to CI config, this will now convert all notebooks.
If files were changed in a notebook directory like requirements.txt or any other files, that notebook will be converted.

This should be implemented in the CI config, for example:
```
if pull_request:
    python convert.py --changed
else:
    python convert.py
```

Also, to prevent an empty index.html file from being generated when no notebooks are produced either a check should be added to html_index.py or to the convert.py script in the notebook repo which would look something like this:

```
converted = run_parsed('.', output_type='HTML', args=args)

if converted:
    logging.getLogger('nbpages').info('Generating index.html')
    make_html_index(converted, './index.tpl')
```

Unsure of which method would be preferred @eteq 

This would dramatically save build minutes for CI pull requests, only converting new/changed notebooks.