### PR TITLE
Add argument to argparser for path to notebooks

### DIFF
--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -61,6 +61,7 @@ def main(max_commits_to_check_in_range=50, nb_path='.'):
     """
     Call this to programmatically use this as a command-line script
     """
+    
     parser = argparse.ArgumentParser()
     parser.add_argument('--commit-range', default=None, dest='range',
                         help='A range of git commits to check. Must be a valid'

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -57,11 +57,11 @@ def visit_content_nbs(nbpath, visitfunc):
     return success
 
 
-def main(max_commits_to_check_in_range=50, nb_path='.'):
+def main(max_commits_to_check_in_range=50, nb_path='jwst_validation_notebooks'):
     """
     Call this to programmatically use this as a command-line script
     """
-    
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--commit-range', default=None, dest='range',
                         help='A range of git commits to check. Must be a valid'

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -66,8 +66,7 @@ def main(max_commits_to_check_in_range=50):
                         help='A range of git commits to check. Must be a valid'
                              'argument for "git rev-list", and git must be '
                              'installed and accessible from the calling shell.')
-    parser.add_argument('--notebook_path', default=None, dest='nb_path',
-                        default='.')
+    parser.add_argument('--notebook_path', default='.', dest='nb_path')
     args = parser.parse_args()
 
     logging.basicConfig()

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -66,12 +66,14 @@ def main(max_commits_to_check_in_range=50):
                         help='A range of git commits to check. Must be a valid'
                              'argument for "git rev-list", and git must be '
                              'installed and accessible from the calling shell.')
+    parser.add_argument('--notebook_path', default=None, dest='nb_path',
+                        default='.')
     args = parser.parse_args()
 
     logging.basicConfig()
     log.setLevel(logging.INFO)
     if args.range is None:
-        success = visit_content_nbs('.', execution_check)
+        success = visit_content_nbs(args.nb_path, execution_check)
     else:
         initial_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()
         if initial_branch == 'HEAD':
@@ -95,7 +97,7 @@ def main(max_commits_to_check_in_range=50):
             for sha in shas:
                 log.info('Checking SHA "{}"'.format(sha))
                 subprocess.check_output('git checkout -q -f {}'.format(sha), shell=True)
-                if not visit_content_nbs('.', execution_check):
+                if not visit_content_nbs(args.nb_path, execution_check):
                     success = False
         finally:
             subprocess.check_output('git checkout ' + initial_branch, shell=True)

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -57,7 +57,7 @@ def visit_content_nbs(nbpath, visitfunc):
     return success
 
 
-def main(max_commits_to_check_in_range=50):
+def main(max_commits_to_check_in_range=50, nb_path='.'):
     """
     Call this to programmatically use this as a command-line script
     """
@@ -71,7 +71,7 @@ def main(max_commits_to_check_in_range=50):
     logging.basicConfig()
     log.setLevel(logging.INFO)
     if args.range is None:
-        success = visit_content_nbs('.', execution_check)
+        success = visit_content_nbs(nb_path, execution_check)
     else:
         initial_branch = subprocess.check_output('git rev-parse --abbrev-ref HEAD', shell=True).decode().strip()
         if initial_branch == 'HEAD':
@@ -95,7 +95,7 @@ def main(max_commits_to_check_in_range=50):
             for sha in shas:
                 log.info('Checking SHA "{}"'.format(sha))
                 subprocess.check_output('git checkout -q -f {}'.format(sha), shell=True)
-                if not visit_content_nbs('.', execution_check):
+                if not visit_content_nbs(nb_path, execution_check):
                     success = False
         finally:
             subprocess.check_output('git checkout ' + initial_branch, shell=True)

--- a/nbpages/check_nbs.py
+++ b/nbpages/check_nbs.py
@@ -57,7 +57,7 @@ def visit_content_nbs(nbpath, visitfunc):
     return success
 
 
-def main(max_commits_to_check_in_range=50, nb_path='jwst_validation_notebooks'):
+def main(max_commits_to_check_in_range=50):
     """
     Call this to programmatically use this as a command-line script
     """


### PR DESCRIPTION
When running the notebooks on the internal Jenkins all of the packages get place along the same file path. Some of the libraries that are necessary for us to execute the JWST validation notebooks have Jupyter Notebooks in them. This causes the Jenkins build to crash because notebooks we want to run for the validation testing effort get mixed up with notebooks that included in the packages we install via pip and conda. To avoid this, we can just point `convert.py` and `nbpages.check_nbs` to the repo with the notebooks you are interested in converting via a command line argument `--notebook_path`. The default is still set to `.` just like before but now users have the options to specify the path in their Jenkins pipeline if needed.